### PR TITLE
Replace Log4j v1 with Log4j v2 1.x bridge (fixes #5)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,9 +82,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>2.17.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
See https://logging.apache.org/log4j/2.x/manual/migration.html for background what this is all about.